### PR TITLE
Modify GTFS stop_times_optimized preparation queries

### DIFF
--- a/src/config/data_variables/gtfs/gtfs_eu.yaml
+++ b/src/config/data_variables/gtfs/gtfs_eu.yaml
@@ -1,6 +1,6 @@
 preparation:
-  start_date: "2023-06-26"
-  end_date: "2023-07-02"
+  start_date: "2022-12-06"
+  num_weeks: 35
   network_dir: "eu"
   target_schema: "gtfs"
   regions: "SELECT nuts_id as id, name, geom FROM public.nuts"

--- a/src/config/data_variables/gtfs/gtfs_eu.yaml
+++ b/src/config/data_variables/gtfs/gtfs_eu.yaml
@@ -2,5 +2,8 @@ preparation:
   start_date: "2022-12-06"
   num_weeks: 35
   network_dir: "eu"
+  network_corrections: {
+    "routes": "corrections_routes.txt"
+  }
   target_schema: "gtfs"
   regions: "SELECT nuts_id as id, name, geom FROM public.nuts"


### PR DESCRIPTION
## Description
- Identify the best calendar week for Monday, Saturday, and Sunday trips for every route
- Specifically retrieve trips active on each trip "group" based on their respective best weeks

## Motivation and Context
After analysing our dataset, we observed that for most regions, trips active on a Monday are also active on other weekdays. Hence, we require only the following distinct "groups" of trips - Monday, Saturday, and Sunday to capture all relevant service patterns.

## Related Issue
#2674
https://github.com/goat-community/goat/issues/2674
